### PR TITLE
fix: extract all events from poll command

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -330,12 +330,18 @@ module.exports = class SSP extends events {
       this.polling = true;
       return this.exec('POLL')
         .then(result => {
-          if (result.info && result.info.code) {
-            this.emit(result.info.name, result.info);
+          if (result.info) {
+            let res = result.info;
+            if (!Array.isArray(result.info)) res = [result.info];
 
-            if (result.info.name === 'DISABLED') {
-              this.poll(false);
-            }
+            res.forEach((info) => {
+              this.emit(info.name, info);
+              // Device reports disabled event on each poll during smart epmy or dispensing, so need to encounter that
+              // Maybe there is better solution, but found no clue in docs
+              if (res.length === 1 && info.name === 'DISABLED') {
+                this.poll(false);
+              }
+            });
           }
 
           if (this.polling) {


### PR DESCRIPTION
Current implemention exxtracts only first event from POLL comand result, when according to documentation https://www.innovative-technology.com/product-files/ssp-manuals/bv20-ssp-manual.pdf
```
The poll command returns the list of events that have occurred within the device since the last poll.
```
This PR adds ability to get all events form POLL command result and fire appropriate events.

Example response
```javascript
{
  success: true,
  status: 'OK',
  command: 'POLL',
  info: [
    {
      code: 179,
      name: 'SMART_EMPTYING',
      description: 'The device is in the process of carrying out its Smart Empty command from the host. The value emptied at the poll point is given in the event data.',
      value: [Array]
    },
    {
      code: 232,
      name: 'DISABLED',
      description: 'The device is not active and unavailable for normal validation functions.'
    }
  ]
}
```