### PR TITLE
fix: poll command results parsing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ module.exports = class SSP extends EventEmitter {
     this.aesEncryption = null;
     this.enabled = false;
     this.polling = false;
+    this.unit_type = null;
   }
 
   open(port, param = {}) {
@@ -247,7 +248,7 @@ module.exports = class SSP extends EventEmitter {
         this.count = eCOUNT;
       }
 
-      let parsedData = parseData(DATA, this.currentCommand, this.protocol_version);
+      let parsedData = parseData(DATA, this.currentCommand, this.protocol_version, this.unit_type);
 
       if (this.debug) {
         console.log(parsedData);
@@ -257,6 +258,9 @@ module.exports = class SSP extends EventEmitter {
         this.createHostEncryptionKeys(parsedData.info.key);
       } else if (this.currentCommand === 'SETUP_REQUEST') {
         this.protocol_version = parsedData.info.protocol_version;
+        this.unit_type = parsedData.info.unit_type;
+      } else if (this.currentCommand === 'UNIT_DATA') {
+        this.unit_type = parsedData.info.unit_type;
       }
 
       return parsedData;


### PR DESCRIPTION
There is a possibility that even data can mactch event code.
For example
Dispensing evnet `[0xDA, 0x01, 0xE8, 0x00, 0x00, 0x00, 0x55, 0x41, 0x48]`
Disabled event: `[0xE8]`
As we see event `0xE8` matches dispensed value `0xE8`

``` json
 {
   "code": 218,
   "name": "DISPENSING",
   "description": "The device is in the process of paying out a requested value. The value paid at the poll is given in the vent data.",
   "value": [
    {
     "value": 232,
     "country_code": "UAH"
    }
   ]
  },
  {
   "code": 232,
   "name": "DISABLED",
   "description": "The device is not active and unavailable for normal validation functions."
  },
```

To fix wrong matches need to take events data length when parsing.

